### PR TITLE
Add accountMode setting for energy meters, fix et340 with phase balancing grids

### DIFF
--- a/software/src/ac_sensor_bridge.cpp
+++ b/software/src/ac_sensor_bridge.cpp
@@ -14,6 +14,12 @@ static bool roleFromDBus(DBusBridge*, QVariant &v)
 	return (QStringList() << "grid" << "pvinverter" << "genset" << "acload").contains(s);
 }
 
+static bool accountingModeFromDBus(DBusBridge*, QVariant &v)
+{
+	int n = v.toInt();
+	return (n >= 0) && (n < 2);
+}
+
 static bool positionFromDBus(DBusBridge*, QVariant &v)
 {
 	int n = v.toInt();
@@ -109,6 +115,9 @@ AcSensorBridge::AcSensorBridge(AcSensor *acSensor, AcSensorSettings *settings,
 	produce("/DeviceInstance", deviceInstance);
 	produce("/Serial", isSecondary ? QString("%1_S").arg(acSensor->serial()) : acSensor->serial());
 	produce("/AllowedRoles", isSecondary ? (QStringList() << "pvinverter" << "acload") : (QStringList() << "grid" << "pvinverter" << "genset" << "acload"));
+	if (isGridmeter) {
+		produce("/AccountingMode", QStringList() << "individual" << "sum");
+	}
 
 	// Publish some information about the known refresh time of these devices.
 	// This is used by hub4control to know how fast it can make its control

--- a/software/src/ac_sensor_settings.cpp
+++ b/software/src/ac_sensor_settings.cpp
@@ -10,6 +10,7 @@ AcSensorSettings::AcSensorSettings(bool supportMultiphase, const QString &serial
 	mIsMultiPhase(false),
 	mPiggyEnabled(false),
 	mPosition(Input1),
+	mAccountingMode(Individual),
 	mL1Energy(0),
 	mL2Energy(0),
 	mL3Energy(0),
@@ -125,6 +126,18 @@ void AcSensorSettings::setL2Position(Position v)
 	mL2Position = v;
 	emit l2PositionChanged();
 	emit l2ProductNameChanged();
+}
+
+AccountingMode AcSensorSetting::accountingMode()
+{
+	return mAccountingMode;
+}
+
+void AcSensorSettings::setAccountingMode(AccountingMode m) {
+	if (mAccountingMode == m)
+		return;
+	mAccountingMode = m;
+	emit accountingModeChanged();
 }
 
 Position AcSensorSettings::position()

--- a/software/src/ac_sensor_settings.h
+++ b/software/src/ac_sensor_settings.h
@@ -7,6 +7,7 @@
 
 Q_DECLARE_METATYPE(Phase)
 Q_DECLARE_METATYPE(Position)
+Q_DECLARE_METATYPE(AccountingMode)
 
 class AcSensorSettings : public QObject
 {
@@ -21,6 +22,7 @@ class AcSensorSettings : public QObject
 	Q_PROPERTY(bool isMultiPhase READ isMultiPhase WRITE setIsMultiPhase NOTIFY isMultiPhaseChanged)
 	Q_PROPERTY(bool piggyEnabled READ piggyEnabled WRITE setPiggyEnabled NOTIFY piggyEnabledChanged)
 	Q_PROPERTY(Position position READ position WRITE setPosition NOTIFY positionChanged)
+	Q_PROPERTY(AccountingMode accountingMode READ accountingMode WRITE setaccountingMode NOTIFY accountingModeChanged)
 	Q_PROPERTY(int deviceInstance READ deviceInstance)
 	Q_PROPERTY(double l1ReverseEnergy READ l1ReverseEnergy WRITE setL1ReverseEnergy NOTIFY l1ReverseEnergyChanged)
 	Q_PROPERTY(double l2ReverseEnergy READ l2ReverseEnergy WRITE setL2ReverseEnergy NOTIFY l2ReverseEnergyChanged)
@@ -111,6 +113,10 @@ public:
 
 	void setPosition(Position p);
 
+	AccountingMode accountingMode();
+
+	void setAccountingMode(AccountingMode a);
+
 	int deviceInstance() const;
 
 	int l2DeviceInstance() const;
@@ -148,6 +154,8 @@ signals:
 
 	void positionChanged();
 
+	void accountingModeChanged();
+
 	void l1ReverseEnergyChanged();
 
 	void l2ReverseEnergyChanged();
@@ -173,6 +181,7 @@ private:
 	bool mIsMultiPhase;
 	bool mPiggyEnabled;
 	Position mPosition;
+	AccountingMode mAccountingMode;
 	double mL1Energy;
 	double mL2Energy;
 	double mL3Energy;

--- a/software/src/ac_sensor_settings_bridge.cpp
+++ b/software/src/ac_sensor_settings_bridge.cpp
@@ -15,6 +15,17 @@ static bool positionToDBus(DBusBridge*, QVariant &v)
 	v = QVariant(static_cast<int>(v.value<Position>()));
 	return true;
 }
+static bool accountingModeFromDBus(DBusBridge*, QVariant &v)
+{
+	v = qVariantFromValue(static_cast<AccountingMode>(v.toInt()));
+	return true;
+}
+
+static bool accountingModeToDBus(DBusBridge*, QVariant &v)
+{
+	v = QVariant(static_cast<int>(v.value<AccountingMode>()));
+	return true;
+}
 
 AcSensorSettingsBridge::AcSensorSettingsBridge(AcSensorSettings *settings, QObject *parent) :
 	DBusBridge(Service, false, parent)
@@ -33,6 +44,8 @@ AcSensorSettingsBridge::AcSensorSettingsBridge(AcSensorSettings *settings, QObje
 			primaryPath + "/IsMultiphase", false);
 	consume(settings, "position", QVariant(0),
 			primaryPath + "/Position", false, positionFromDBus, positionToDBus);
+	consume(settings, "accountingMode", QVariant(0),
+			primaryPath + "/AccountingMode", false, accountingModeFromDBus, accountingModeToDBus);
 	consume(settings, "l1ReverseEnergy", 0.0, 0.0, 1e6,
 			primaryPath + "/L1ReverseEnergy", true);
 	consume(settings, "l2ReverseEnergy", 0.0, 0.0, 1e6,

--- a/software/src/ac_sensor_updater.cpp
+++ b/software/src/ac_sensor_updater.cpp
@@ -942,6 +942,15 @@ void AcSensorUpdater::processAcquisitionData(const QList<quint16> &registers)
 				// other meters.
 				v = qAbs(getDouble(registers, ra.regOffset, 0.1));
 
+				// Ignore per-phase counters if mode is sum, this will then correct ET340s weird sum counts
+				// void DataProcessor::setNegativeEnergy(double sum) does the phase correction
+				if (mSettings->accountingMode() === Sum) {
+					if ( ra.phase == MultiPhase) {
+						dest->setNegativeEnergy(v);
+					}
+					break;
+				}
+
 				// These meters dont' have per-phase reverse counters
 				if ((mAcSensor->protocolType() == AcSensor::Em24Protocol ||
 					mAcSensor->protocolType() == AcSensor::Em540Protocol ||
@@ -952,6 +961,7 @@ void AcSensorUpdater::processAcquisitionData(const QList<quint16> &registers)
 				} else {
 					dest->setNegativeEnergy(ra.phase, v);
 					if (setPhaseL1)
+						// Device has has no per phase count, so L1 is set for data completion
 						dest->setNegativeEnergy(PhaseL1, v);
 				}
 				break;

--- a/software/src/defines.h
+++ b/software/src/defines.h
@@ -18,6 +18,11 @@ enum Position {
 	Input2 = 2
 };
 
+enum AccountingMode {
+	Individual = 0,
+	Sum = 1,
+};
+
 inline quint8 msb(quint16 d)
 {
 	return d >> 8;


### PR DESCRIPTION
I have done some calculations and compared them with my providers grid meter readings, this should resolve the issue.

This PR is a draft, I'm unable to buiild it right now, as the venus sdk does not work on my M2 Macbook and I also can't figure out a way to build it on my cerbo :(

In this screenshot, the green numbers (ET340 kWh Total) are correct, the red (ET340 kWh per Phase) are wrong and the red are those that are counted for the VRM sums, to resolve this I propose to ignore the per phase readings and spread the total readings on the phases (this is how it works for em24). 
<img width="748" alt="image" src="https://user-images.githubusercontent.com/628787/224572137-4774cf1a-c5fd-44fb-9636-9f804c42abd3.png">
<img width="1180" alt="image" src="https://user-images.githubusercontent.com/628787/224572167-3db17af9-64ad-4fc2-b5dd-81844f59e10c.png">


Changes: 
feat(accountingMode): add setting "accountingMode", if set to sum, the individual energy counters for each phase of the meter will be ignored, this fix the incorrect behaviour for ET340 devices when compared to phase balancing grid meters
